### PR TITLE
Use github action matrix in CI

### DIFF
--- a/.github/workflows/test-brew-formulae.yaml
+++ b/.github/workflows/test-brew-formulae.yaml
@@ -25,7 +25,7 @@ jobs:
           brew list bats && brew uninstall bats || echo "bats is not present"
           brew install bats-core
       - name: INSTALL bats-support
-        if: contains(['bats-assert'],env.PACKAGE)
+        if: contains(env.PACKAGE, 'bats-assert')
         run: brew install --build-from-source --verbose bats-support
       - name: INSTALL local formula
         run: brew install --build-from-source --verbose $PACKAGE

--- a/.github/workflows/test-brew-formulae.yaml
+++ b/.github/workflows/test-brew-formulae.yaml
@@ -26,7 +26,7 @@ jobs:
           brew list bats && brew uninstall bats || echo "bats is not present"
           brew install bats-core
       - name: INSTALL bats-support
-        if: contains(env.PACKAGE, 'bats-assert')
+        if: ${{ env.PACKAGE == 'bats-assert' || env.PACKAGE == 'bats-file' }}
         run: brew install --build-from-source --verbose bats-support
       - name: INSTALL local formula
         run: brew install --build-from-source --verbose $PACKAGE

--- a/.github/workflows/test-brew-formulae.yaml
+++ b/.github/workflows/test-brew-formulae.yaml
@@ -1,4 +1,4 @@
-name: test-formulas
+name: test-bats-libs-formulae
 
 on:
   push:

--- a/.github/workflows/test-brew-formulae.yaml
+++ b/.github/workflows/test-brew-formulae.yaml
@@ -7,9 +7,13 @@ on:
   workflow_dispatch:
 
 jobs:
-
-  test-support-formula:
+  test-packages:
+    strategy:
+      matrix:
+        package: [bats-support, bats-assert, bats-detik, bats-file]
     runs-on: macos-latest
+    env:
+      PACKAGE: ${{ matrix.package }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Homebrew
@@ -20,72 +24,14 @@ jobs:
         run: |
           brew list bats && brew uninstall bats || echo "bats is not present"
           brew install bats-core
-      - name: Bats-support AUDIT
-        run: brew audit --new-formula --formula Formula/bats-support.rb
-      - name: Bats-support INSTALL
+      - name: INSTALL bats-support
+        if: contains(['bats-assert'],env.PACKAGE)
         run: brew install --build-from-source --verbose bats-support
-      - name: Bats-support TEST
-        run: brew test Formula/bats-support.rb
-
-  test-detik-formula:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Brew version output
-        run: brew --version
-      - name: INSTALL bats-core
-        run: |
-          brew list bats && brew uninstall bats || echo "bats is not present"
-          brew install bats-core
-      - name: Bats-detik AUDIT
-        run: brew audit --new-formula --formula Formula/bats-detik.rb
-      - name: Bats-detik INSTALL
-        run: brew install --build-from-source --verbose bats-detik
-      - name: Bats-detik TEST
-        run: brew test Formula/bats-detik.rb
-
-  test-assert-formula:
-    needs: [test-support-formula]
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Brew version output
-        run: brew --version
-      - name: INSTALL bats-core
-        run: |
-          brew list bats && brew uninstall bats || echo "bats is not present"
-          brew install bats-core
-      - name: INSTALL local bats-support formula
-        run: brew install --build-from-source --verbose bats-support
-      - name: Bats-assert AUDIT
-        run: brew audit --new-formula --formula Formula/bats-assert.rb
-      - name: Bats-assert INSTALL
-        run: brew install --build-from-source --verbose bats-assert
-      - name: Bats-assert TEST
-        run: brew test Formula/bats-assert.rb
-
-  test-file-formula:
-    needs: [test-support-formula]
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Brew version output
-        run: brew --version
-      - name: INSTALL bats-core
-        run: |
-          brew list bats && brew uninstall bats || echo "bats is not present"
-          brew install bats-core
-      - name: INSTALL local bats-support formula
-        run: brew install --build-from-source --verbose bats-support
-      - name: Bats-file AUDIT
-        run: brew audit --new-formula --formula Formula/bats-file.rb
-      - name: Bats-file INSTALL
-        run: brew install --build-from-source --verbose bats-file
-      - name: Bats-file TEST
-        run: brew test Formula/bats-file.rb
+      - name: INSTALL local formula
+        run: brew install --build-from-source --verbose $PACKAGE
+      - name: AUDIT
+        run: brew audit --new-formula --formula Formula/$PACKAGE.rb
+      - name: INSTALL
+        run: brew install --build-from-source --verbose $PACKAGE
+      - name: TEST
+        run: brew test Formula/$PACKAGE.rb

--- a/.github/workflows/test-brew-formulae.yaml
+++ b/.github/workflows/test-brew-formulae.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-packages:
     strategy:
+      fail-fast: false
       matrix:
         package: [bats-support, bats-assert, bats-detik, bats-file]
     runs-on: macos-latest

--- a/.github/workflows/test-brew-formulas.yaml
+++ b/.github/workflows/test-brew-formulas.yaml
@@ -17,7 +17,9 @@ jobs:
       - name: Brew version output
         run: brew --version
       - name: INSTALL bats-core
-        run: brew uninstall bats; brew install bats-core
+        run: |
+          brew list bats && brew uninstall bats || echo "bats is not present"
+          brew install bats-core
       - name: Bats-support AUDIT
         run: brew audit --new-formula --formula Formula/bats-support.rb
       - name: Bats-support INSTALL

--- a/.github/workflows/test-brew-formulas.yaml
+++ b/.github/workflows/test-brew-formulas.yaml
@@ -36,7 +36,9 @@ jobs:
       - name: Brew version output
         run: brew --version
       - name: INSTALL bats-core
-        run: brew uninstall bats; brew install bats-core
+        run: |
+          brew list bats && brew uninstall bats || echo "bats is not present"
+          brew install bats-core
       - name: Bats-detik AUDIT
         run: brew audit --new-formula --formula Formula/bats-detik.rb
       - name: Bats-detik INSTALL
@@ -54,7 +56,9 @@ jobs:
       - name: Brew version output
         run: brew --version
       - name: INSTALL bats-core
-        run: brew uninstall bats; brew install bats-core
+        run: |
+          brew list bats && brew uninstall bats || echo "bats is not present"
+          brew install bats-core
       - name: INSTALL bats-support from current branch
         run: |
           brew tap bats-core/bats-core --branch ${GITHUB_REF##*/}
@@ -76,7 +80,9 @@ jobs:
       - name: Brew version output
         run: brew --version
       - name: INSTALL bats-core
-        run: brew uninstall bats; brew install bats-core
+        run: |
+          brew list bats && brew uninstall bats || echo "bats is not present"
+          brew install bats-core
       - name: INSTALL bats-support from current branch
         run: |
           brew tap bats-core/bats-core --branch ${GITHUB_REF##*/}

--- a/.github/workflows/test-brew-formulas.yaml
+++ b/.github/workflows/test-brew-formulas.yaml
@@ -59,10 +59,8 @@ jobs:
         run: |
           brew list bats && brew uninstall bats || echo "bats is not present"
           brew install bats-core
-      - name: INSTALL bats-support from current branch
-        run: |
-          brew tap bats-core/bats-core --branch ${GITHUB_REF##*/}
-          brew install bats-support
+      - name: INSTALL local bats-support formula
+        run: brew install --build-from-source --verbose bats-support
       - name: Bats-assert AUDIT
         run: brew audit --new-formula --formula Formula/bats-assert.rb
       - name: Bats-assert INSTALL
@@ -83,10 +81,8 @@ jobs:
         run: |
           brew list bats && brew uninstall bats || echo "bats is not present"
           brew install bats-core
-      - name: INSTALL bats-support from current branch
-        run: |
-          brew tap bats-core/bats-core --branch ${GITHUB_REF##*/}
-          brew install bats-support
+      - name: INSTALL local bats-support formula
+        run: brew install --build-from-source --verbose bats-support
       - name: Bats-file AUDIT
         run: brew audit --new-formula --formula Formula/bats-file.rb
       - name: Bats-file INSTALL

--- a/.github/workflows/test-brew-formulas.yaml
+++ b/.github/workflows/test-brew-formulas.yaml
@@ -2,7 +2,7 @@ name: test-formulas
 
 on:
   push:
-    branches: [ split-github-ci ]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-brew-formulas.yaml
+++ b/.github/workflows/test-brew-formulas.yaml
@@ -2,12 +2,13 @@ name: test-formulas
 
 on:
   push:
-    branches: [ main ]
+    branches: [ split-github-ci ]
   pull_request:
   workflow_dispatch:
 
 jobs:
-  test-formulas:
+
+  test-support-formula:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,21 +24,64 @@ jobs:
         run: brew install --build-from-source --verbose bats-support
       - name: Bats-support TEST
         run: brew test Formula/bats-support.rb
-      - name: Bats-assert AUDIT
-        run: brew audit --new-formula --formula Formula/bats-assert.rb
-      - name: Bats-assert INSTALL
-        run: brew install --build-from-source --verbose bats-assert
-      - name: Bats-assert TEST
-        run: brew test Formula/bats-assert.rb
-      - name: Bats-file AUDIT
-        run: brew audit --new-formula --formula Formula/bats-file.rb
-      - name: Bats-file INSTALL
-        run: brew install --build-from-source --verbose bats-file
-      - name: Bats-file TEST
-        run: brew test Formula/bats-file.rb
+
+  test-detik-formula:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Brew version output
+        run: brew --version
+      - name: INSTALL bats-core
+        run: brew uninstall bats; brew install bats-core
       - name: Bats-detik AUDIT
         run: brew audit --new-formula --formula Formula/bats-detik.rb
       - name: Bats-detik INSTALL
         run: brew install --build-from-source --verbose bats-detik
       - name: Bats-detik TEST
         run: brew test Formula/bats-detik.rb
+
+  test-assert-formula:
+    needs: [test-support-formula]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Brew version output
+        run: brew --version
+      - name: INSTALL bats-core
+        run: brew uninstall bats; brew install bats-core
+      - name: INSTALL bats-support from current branch
+        run: |
+          brew tap bats-core/bats-core --branch ${GITHUB_REF##*/}
+          brew install bats-support
+      - name: Bats-assert AUDIT
+        run: brew audit --new-formula --formula Formula/bats-assert.rb
+      - name: Bats-assert INSTALL
+        run: brew install --build-from-source --verbose bats-assert
+      - name: Bats-assert TEST
+        run: brew test Formula/bats-assert.rb
+
+  test-file-formula:
+    needs: [test-support-formula]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Brew version output
+        run: brew --version
+      - name: INSTALL bats-core
+        run: brew uninstall bats; brew install bats-core
+      - name: INSTALL bats-support from current branch
+        run: |
+          brew tap bats-core/bats-core --branch ${GITHUB_REF##*/}
+          brew install bats-support
+      - name: Bats-file AUDIT
+        run: brew audit --new-formula --formula Formula/bats-file.rb
+      - name: Bats-file INSTALL
+        run: brew install --build-from-source --verbose bats-file
+      - name: Bats-file TEST
+        run: brew test Formula/bats-file.rb


### PR DESCRIPTION
* Split the original job in 4 different one
* Bats-assert and bats-file need the bats-support job to be correctly terminated (see `needs`)
* In bats-assert and bats-file we don't rely on brew automatic dependency install, instead we still install bats-support from local Formula file in PR branch. The reason behind this is that in case of future bats-support release we can test both the bats-support build and the file/assert tests with that new bats-support version.
* Fix misspelling: `Formulae` not `Formulas`

In case of approval please squash commits before merging this PR